### PR TITLE
fix(fs): handle folder info array response

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,11 @@
 package sdk
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrObjectNotFound = errors.New("object not found")
 
 type Error struct {
 	Code    int64  `json:"code"`

--- a/fs.go
+++ b/fs.go
@@ -2,6 +2,7 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -156,6 +157,32 @@ type GetFolderInfoResp struct {
 		FileName string `json:"file_name"`
 	} `json:"paths"`
 }
+
+func (r *GetFolderInfoResp) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil
+	}
+	if data[0] == '[' {
+		var resp []getFolderInfoResp
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return err
+		}
+		if len(resp) == 0 {
+			return ErrObjectNotFound
+		}
+		*r = GetFolderInfoResp(resp[0])
+		return nil
+	}
+	var resp getFolderInfoResp
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return err
+	}
+	*r = GetFolderInfoResp(resp)
+	return nil
+}
+
+type getFolderInfoResp GetFolderInfoResp
 
 // GetFolderInfo: https://www.yuque.com/115yun/open/rl8zrhe2nag21dfw
 func (c *Client) GetFolderInfo(ctx context.Context, fileID string) (*GetFolderInfoResp, error) {

--- a/fs_test.go
+++ b/fs_test.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestGetFolderInfoRespUnmarshalObject(t *testing.T) {
+	var resp GetFolderInfoResp
+	err := json.Unmarshal([]byte(`{"file_id":"1","file_name":"dir","file_category":"0"}`), &resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.FileID != "1" || resp.FileName != "dir" || resp.FileCategory != "0" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestGetFolderInfoRespUnmarshalArray(t *testing.T) {
+	var resp GetFolderInfoResp
+	err := json.Unmarshal([]byte(`[{"file_id":"1","file_name":"dir","file_category":"0"}]`), &resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.FileID != "1" || resp.FileName != "dir" || resp.FileCategory != "0" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestGetFolderInfoRespUnmarshalEmptyArray(t *testing.T) {
+	var resp GetFolderInfoResp
+	err := json.Unmarshal([]byte(`[]`), &resp)
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("expected ErrObjectNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

This fixes the root cause behind OpenListTeam/OpenList#2562.

The 115 Open `/open/folder/get_info` API may return `data` as an array for path-based folder info lookups, especially when the requested path is missing. The SDK currently always unmarshals `data` into `GetFolderInfoResp`, so callers receive:

```text
json: cannot unmarshal array into Go value of type sdk.GetFolderInfoResp
```

This change makes `GetFolderInfoResp` accept both shapes:

- object: existing behavior
- non-empty array: use the first item
- empty array: return `ErrObjectNotFound`

This allows callers such as OpenList to distinguish missing objects from real JSON/schema failures.

## Related

- OpenList issue: OpenListTeam/OpenList#2562
- OpenList PR discussion: OpenListTeam/OpenList#2563

## Testing

- `gofmt -w fs.go error.go fs_test.go`
- `git diff --check`

I did not run `go test` locally because the downstream OpenList task is under a local testing constraint that forbids generating compiled test artifacts/caches.

## AI Disclosure

This PR includes AI-assisted content.

Tools used:

- OpenAI Codex

Usage scope:

- Code generation
- Test drafting
- PR description drafting

I reviewed and validated the AI-assisted content before submission. The commit includes `Co-authored-by: OpenAI Codex <codex@openai.com>` attribution.
